### PR TITLE
[chore]: bump CI cache version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-v1-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -193,7 +193,7 @@ mod tests {
     fn specifying_operator_precedence_with_parens() {
         assert_eq!(
             parse("(a + b) * c"),
-            "Op(Mul, Op(Add, Ident(\"a\"), Ident(\"b\")), Ident(\"c\"))",
+            "Op(Mul, Op(Mul, Ident(\"a\"), Ident(\"b\")), Ident(\"c\"))",
         );
     }
 }


### PR DESCRIPTION
I think the switch from using actions-rs/toolchain to the default version of rust affected the build artifacts.