### PR TITLE
Infer Let and Op

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,34 +1,40 @@
+use chumsky::prelude::*;
 use std::collections::HashMap;
 
-use nouveau_lib::literal::Literal;
-use nouveau_lib::substitutable::*;
-use nouveau_lib::syntax::{BindingIdent, Expr};
-use nouveau_lib::types::*;
+use nouveau_lib::parser::*;
+use nouveau_lib::context::Env;
+use nouveau_lib::infer::*;
 
 fn main() {
     println!("Hello, world!");
 
-    let t = Type::Lam(TLam {
-        args: vec![Type::Prim(Primitive::Num)],
-        ret: Box::new(Type::Prim(Primitive::Num)),
-    });
+    // let t = Type::Lam(TLam {
+    //     args: vec![Type::Prim(Primitive::Num)],
+    //     ret: Box::new(Type::Prim(Primitive::Num)),
+    // });
 
-    if let Type::Lam(TLam { args, .. }) = &t {
-        println!("t is a lambad and it takes {} args", args.len());
-    }
+    // if let Type::Lam(TLam { args, .. }) = &t {
+    //     println!("t is a lambad and it takes {} args", args.len());
+    // }
 
-    println!("t = {:?}", &t);
+    // println!("t = {:?}", &t);
 
-    let expr = Expr::Lam(
-        vec![BindingIdent::Ident(String::from("x"))],
-        // TODO: add helpers like Lit::from(5.0), Lit::from("hello"), etc.
-        Box::new(Expr::Lit(Literal::Num(String::from("5.0")))),
-        false,
-    );
+    // let expr = Expr::Lam(
+    //     vec![BindingIdent::Ident(String::from("x"))],
+    //     // TODO: add helpers like Lit::from(5.0), Lit::from("hello"), etc.
+    //     Box::new(Expr::Lit(Literal::Num(String::from("5.0")))),
+    //     false,
+    // );
 
-    let sub = HashMap::new();
-    t.apply(&sub);
-    t.apply(&sub);
+    // let sub = HashMap::new();
+    // t.apply(&sub);
+    // t.apply(&sub);
 
-    println!("expr = {:?}", &expr);
+    // println!("expr = {:?}", &expr);
+
+    let env: Env = HashMap::new();
+    let expr = parser().parse("5 + 10").unwrap();
+    let result = infer_expr(env, &expr);
+
+    assert_eq!(format!("{}", result), "5");
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use chumsky::prelude::*;
 
 use super::literal::Literal;
-use super::syntax::{BinOp, BindingIdent, Expr};
+use super::syntax::{BinOp, BindingIdent, Expr, Pattern};
 
 pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
     let ident = text::ident().padded();
@@ -81,7 +81,9 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .then(expr.clone())
             .then_ignore(just("in").padded())
             .then(expr.clone())
-            .map(|((name, value), body)| Expr::Let(name, Box::new(value), Box::new(body)));
+            .map(|((name, value), body)| {
+                Expr::Let(Pattern::Ident(name), Box::new(value), Box::new(body))
+            });
 
         app.or(lam).or(r#let).or(sum)
     });
@@ -153,7 +155,7 @@ mod tests {
     fn simple_let() {
         assert_eq!(
             parse("let x = 5 in x"),
-            "Let(\"x\", Lit(Num(\"5\")), Ident(\"x\"))"
+            "Let(Ident(\"x\"), Lit(Num(\"5\")), Ident(\"x\"))"
         );
     }
 
@@ -161,7 +163,7 @@ mod tests {
     fn nested_let() {
         assert_eq!(
             parse("let x = 5 in let y = 10 in z"),
-            "Let(\"x\", Lit(Num(\"5\")), Let(\"y\", Lit(Num(\"10\")), Ident(\"z\")))",
+            "Let(Ident(\"x\"), Lit(Num(\"5\")), Let(Ident(\"y\"), Lit(Num(\"10\")), Ident(\"z\")))",
         );
     }
 

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,13 +2,13 @@ use super::literal::Literal;
 
 // TODO: rename this to something else since we can't use it
 // let bindings
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BindingIdent {
     Ident(String),
     Rest(String),
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinOp {
     Add,
     Sub,
@@ -16,12 +16,18 @@ pub enum BinOp {
     Div,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     App(Box<Expr>, Vec<Expr>),
     Ident(String),
     Lam(Vec<BindingIdent>, Box<Expr>, bool),
-    Let(String, Box<Expr>, Box<Expr>),
+    Let(Pattern, Box<Expr>, Box<Expr>),
     Lit(Literal),
     Op(BinOp, Box<Expr>, Box<Expr>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Pattern {
+    Ident(String),
+    // TODO: add more patterns later
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -100,6 +100,7 @@ impl From<&TLam> for Type {
     }
 }
 
+// TODO: add `id` to each of these (maybe we could make having an `id` a trait)
 #[derive(Clone, Debug)]
 pub enum Type {
     Var(TVar),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -25,6 +25,24 @@ fn infer_lam() {
 }
 
 #[test]
+fn infer_let() {
+    let env: Env = HashMap::new();
+    let expr = parser().parse("let x = 5 in x").unwrap();
+    let result = infer_expr(env, &expr);
+
+    assert_eq!(format!("{}", result), "5");
+}
+
+#[test]
+fn infer_op() {
+    let env: Env = HashMap::new();
+    let expr = parser().parse("5 + 10").unwrap();
+    let result = infer_expr(env, &expr);
+
+    assert_eq!(format!("{}", result), "number");
+}
+
+#[test]
 fn type_debug_trait() {
     let t = Type::from(TLam {
         // TODO: add From trait impls to go from Primitive to Type


### PR DESCRIPTION
This PR also:
- introduces the idea of sub-typing by allow number literals to be used where numbers are expected (same for strings and booleans)
- looks up the id of type variables when applying substitutions
