### PR TITLE
[parser]: update Expr enum to use structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24,6 +30,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d02796e4586c6c41aeb68eae9bfb4558a522c35f1430c14b40136c3706e09e4"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
 ]
 
 [[package]]
@@ -61,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +97,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
+name = "insta"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "689960f187c43c01650c805fb6bc6f55ab944499d86d4ffe9474ad78991d8e94"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "similar",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +134,12 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "lazy_static"
@@ -93,20 +154,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "nouveau"
 version = "0.1.0"
 dependencies = [
  "chumsky",
+ "insta",
  "itertools",
- "partial_application",
  "test-case",
 ]
 
 [[package]]
-name = "partial_application"
-version = "0.2.1"
+name = "once_cell"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f926567968c32d22274b8eb721210363e54dcd8d2c960dd8533aa3be78143081"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "proc-macro-error"
@@ -157,6 +224,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "serde"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.136"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+
+[[package]]
 name = "syn"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +287,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -206,3 +338,34 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "nouveau_lib"
 [dependencies]
 chumsky = "0.8.0"
 itertools = "0.10.3"
-partial_application = "0.2.1"
 
 [dev-dependencies]
 test-case = "2.0.2"
+insta = "1.13.0"

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -113,11 +113,11 @@ type InferResult = (Type, Vec<Constraint>);
 
 fn infer(expr: &Expr, ctx: &Context) -> InferResult {
     match expr {
-        Expr::Ident(name) => {
+        Expr::Ident {name} => {
             let ty = ctx.lookup_env(name);
             (ty, vec![])
         }
-        Expr::App(lam, args) => {
+        Expr::App {lam, args} => {
             let (t_fn, cs_fn) = infer(lam, ctx);
             let (t_args, cs_args) = infer_many(args, ctx);
             let tv = ctx.fresh();
@@ -137,7 +137,7 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (Type::from(tv), constraints)
         }
-        Expr::Lam(args, body, _is_async) => {
+        Expr::Lam {args, body, ..} => {
             // Creates a new type variable for each arg
             let arg_tvs: Vec<_> = args.iter().map(|_| Type::Var(ctx.fresh())).collect();
             let mut new_ctx = ctx.clone();
@@ -159,10 +159,10 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (lam_ty, cs)
         }
-        Expr::Let(pat, value, body) => {
+        Expr::Let {pattern, value, body} => {
             let (t1, cs1) = infer(&value, &ctx);
             let subs = run_solve(&cs1, &ctx);
-            let (new_ctx, new_cs) = infer_pattern(pat, &t1, &subs, ctx);
+            let (new_ctx, new_cs) = infer_pattern(pattern, &t1, &subs, ctx);
             let (t2, cs2) = infer(body, &new_ctx);
 
             let mut cs: Vec<Constraint> = Vec::new();
@@ -172,8 +172,9 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (t2.apply(&subs), vec![])
         }
-        Expr::Lit(lit) => (Type::from(lit), vec![]),
-        Expr::Op(_binop, left, right) => {
+        Expr::Lit {literal} => (Type::from(literal), vec![]),
+        // TODO: check the `op` field when we introduce comparison operators
+        Expr::Op {left, right, ..} => {
             let left = Box::as_ref(left);
             let right = Box::as_ref(right);
             let (ts, cs) = infer_many(&[left.clone(), right.clone()], ctx);

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -113,11 +113,11 @@ type InferResult = (Type, Vec<Constraint>);
 
 fn infer(expr: &Expr, ctx: &Context) -> InferResult {
     match expr {
-        Expr::Ident {name} => {
+        Expr::Ident { name } => {
             let ty = ctx.lookup_env(name);
             (ty, vec![])
         }
-        Expr::App {lam, args} => {
+        Expr::App { lam, args } => {
             let (t_fn, cs_fn) = infer(lam, ctx);
             let (t_args, cs_args) = infer_many(args, ctx);
             let tv = ctx.fresh();
@@ -137,7 +137,7 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (Type::from(tv), constraints)
         }
-        Expr::Lam {args, body, ..} => {
+        Expr::Lam { args, body, .. } => {
             // Creates a new type variable for each arg
             let arg_tvs: Vec<_> = args.iter().map(|_| Type::Var(ctx.fresh())).collect();
             let mut new_ctx = ctx.clone();
@@ -147,8 +147,8 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
                     ty: tv.clone(),
                 };
                 match arg {
-                    BindingIdent::Ident(name) => new_ctx.env.insert(name.to_string(), scheme),
-                    BindingIdent::Rest(name) => new_ctx.env.insert(name.to_string(), scheme),
+                    BindingIdent::Ident { name } => new_ctx.env.insert(name.to_string(), scheme),
+                    BindingIdent::Rest { name } => new_ctx.env.insert(name.to_string(), scheme),
                 };
             }
             let (ret_ty, cs) = infer(body, &new_ctx);
@@ -159,7 +159,11 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (lam_ty, cs)
         }
-        Expr::Let {pattern, value, body} => {
+        Expr::Let {
+            pattern,
+            value,
+            body,
+        } => {
             let (t1, cs1) = infer(&value, &ctx);
             let subs = run_solve(&cs1, &ctx);
             let (new_ctx, new_cs) = infer_pattern(pattern, &t1, &subs, ctx);
@@ -172,9 +176,9 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (t2.apply(&subs), vec![])
         }
-        Expr::Lit {literal} => (Type::from(literal), vec![]),
+        Expr::Lit { literal } => (Type::from(literal), vec![]),
         // TODO: check the `op` field when we introduce comparison operators
-        Expr::Op {left, right, ..} => {
+        Expr::Op { left, right, .. } => {
             let left = Box::as_ref(left);
             let right = Box::as_ref(right);
             let (ts, cs) = infer_many(&[left.clone(), right.clone()], ctx);
@@ -191,7 +195,7 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
                         args: vec![Type::from(Primitive::Num), Type::from(Primitive::Num)],
                         ret: Box::from(Type::from(Primitive::Num)),
                     }),
-                )
+                ),
             };
             cs.push(c);
 
@@ -209,7 +213,7 @@ fn infer_pattern(
     let scheme = generalize(&ctx.env.apply(subs), &ty.apply(subs));
 
     match pattern {
-        Pattern::Ident(name) => {
+        Pattern::Ident { name } => {
             let mut new_ctx = ctx.clone();
             new_ctx.env.insert(name.to_owned(), scheme);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,3 @@ pub mod parser;
 pub mod substitutable;
 pub mod syntax;
 pub mod types;
-
-#[macro_use]
-extern crate partial_application;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,7 +75,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             });
 
         let param_list = ident
-            .map_with_span(|name, _| BindingIdent::Ident(name))
+            .map_with_span(|name, _| BindingIdent::Ident { name })
             .padded()
             .separated_by(just(","))
             .allow_trailing()
@@ -97,7 +97,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .then_ignore(just("in").padded())
             .then(expr.clone())
             .map_with_span(|((name, value), body), _| Expr::Let {
-                pattern: Pattern::Ident(name),
+                pattern: Pattern::Ident { name },
                 value: Box::new(value),
                 body: Box::new(body),
             });
@@ -117,12 +117,12 @@ mod tests {
         insta::assert_debug_snapshot!(parser().parse("(a, b) => c").unwrap(), @r###"
         Lam {
             args: [
-                Ident(
-                    "a",
-                ),
-                Ident(
-                    "b",
-                ),
+                Ident {
+                    name: "a",
+                },
+                Ident {
+                    name: "b",
+                },
             ],
             body: Ident {
                 name: "c",
@@ -152,9 +152,9 @@ mod tests {
         insta::assert_debug_snapshot!(parser().parse("(a) => \"hello\"").unwrap(), @r###"
         Lam {
             args: [
-                Ident(
-                    "a",
-                ),
+                Ident {
+                    name: "a",
+                },
             ],
             body: Lit {
                 literal: Str(
@@ -246,9 +246,9 @@ mod tests {
     fn simple_let() {
         insta::assert_debug_snapshot!(parser().parse("let x = 5 in x").unwrap(), @r###"
         Let {
-            pattern: Ident(
-                "x",
-            ),
+            pattern: Ident {
+                name: "x",
+            },
             value: Lit {
                 literal: Num(
                     "5",
@@ -265,18 +265,18 @@ mod tests {
     fn nested_let() {
         insta::assert_debug_snapshot!(parser().parse("let x = 5 in let y = 10 in x + y").unwrap(), @r###"
         Let {
-            pattern: Ident(
-                "x",
-            ),
+            pattern: Ident {
+                name: "x",
+            },
             value: Lit {
                 literal: Num(
                     "5",
                 ),
             },
             body: Let {
-                pattern: Ident(
-                    "y",
-                ),
+                pattern: Ident {
+                    name: "y",
+                },
                 value: Lit {
                     literal: Num(
                         "10",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,50 +7,58 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
     let ident = text::ident().padded();
 
     let num = text::int(10)
-        .map(|s: String| Expr::Lit(Literal::Num(s)))
+        .map_with_span(|s, _| Expr::Lit {
+            literal: Literal::Num(s),
+        })
         .padded();
 
     let str_ = just("\"")
         .ignore_then(filter(|c| *c != '"').repeated())
         .then_ignore(just('"'))
         .collect::<String>()
-        .map(|s: String| Expr::Lit(Literal::Str(s)));
+        .map_with_span(|s, _| Expr::Lit {
+            literal: Literal::Str(s),
+        });
 
     let lit = num.or(str_);
 
     let expr = recursive(|expr| {
         let atom = num
             .or(expr.clone().delimited_by(just("("), just(")")))
-            .or(ident.map(Expr::Ident))
+            .or(ident.map_with_span(|name, _| Expr::Ident { name }))
             .or(lit);
 
         let product = atom
             .clone()
             .then(
-                just("*")
-                    .padded()
-                    .to(partial!(Expr::Op => BinOp::Mul, _, _) as fn(_, _) -> _)
-                    .or(just("/")
-                        .padded()
-                        .to(partial!(Expr::Op => BinOp::Div, _, _) as fn(_, _) -> _))
-                    .then(atom.clone())
-                    .repeated(),
+                choice((
+                    just("*").padded().to(BinOp::Mul),
+                    just("/").padded().to(BinOp::Div),
+                ))
+                .then(atom.clone())
+                .repeated(),
             )
-            .foldl(|lhs, (op_con, rhs)| op_con(Box::new(lhs), Box::new(rhs)));
+            .foldl(|left, (op, right)| Expr::Op {
+                op,
+                left: Box::from(left),
+                right: Box::from(right),
+            });
 
         let sum = product
             .clone()
             .then(
-                just("+")
-                    .padded()
-                    .to(partial!(Expr::Op => BinOp::Add, _, _) as fn(_, _) -> _)
-                    .or(just("-")
-                        .padded()
-                        .to(partial!(Expr::Op => BinOp::Sub, _, _) as fn(_, _) -> _))
-                    .then(product.clone())
-                    .repeated(),
+                choice((
+                    just("+").padded().to(BinOp::Add),
+                    just("-").padded().to(BinOp::Sub),
+                ))
+                .then(product.clone())
+                .repeated(),
             )
-            .foldl(|lhs, (op_con, rhs)| op_con(Box::new(lhs), Box::new(rhs)));
+            .foldl(|left, (op, right)| Expr::Op {
+                op,
+                left: Box::from(left),
+                right: Box::from(right),
+            });
 
         let app = atom
             .clone()
@@ -61,10 +69,13 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
                     .allow_trailing()
                     .delimited_by(just("("), just(")")),
             )
-            .map(|(func, args)| Expr::App(Box::new(func), args));
+            .map_with_span(|(func, args), _| Expr::App {
+                lam: Box::new(func),
+                args,
+            });
 
         let param_list = ident
-            .map(BindingIdent::Ident)
+            .map_with_span(|name, _| BindingIdent::Ident(name))
             .padded()
             .separated_by(just(","))
             .allow_trailing()
@@ -73,7 +84,11 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
         let lam = param_list
             .then_ignore(just("=>").padded())
             .then(expr.clone())
-            .map(|(args, body)| Expr::Lam(args, Box::new(body), false));
+            .map_with_span(|(args, body), _| Expr::Lam {
+                args,
+                body: Box::new(body),
+                is_async: false,
+            });
 
         let r#let = just("let")
             .ignore_then(ident)
@@ -81,8 +96,10 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
             .then(expr.clone())
             .then_ignore(just("in").padded())
             .then(expr.clone())
-            .map(|((name, value), body)| {
-                Expr::Let(Pattern::Ident(name), Box::new(value), Box::new(body))
+            .map_with_span(|((name, value), body), _| Expr::Let {
+                pattern: Pattern::Ident(name),
+                value: Box::new(value),
+                body: Box::new(body),
             });
 
         app.or(lam).or(r#let).or(sum)
@@ -95,107 +112,277 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
 mod tests {
     use super::*;
 
-    fn parse(s: &str) -> String {
-        format!("{:?}", parser().parse(s).unwrap())
-    }
-
     #[test]
     fn fn_with_multiple_params() {
-        assert_eq!(
-            parse("(a, b) => c"),
-            "Lam([Ident(\"a\"), Ident(\"b\")], Ident(\"c\"), false)"
-        );
+        insta::assert_debug_snapshot!(parser().parse("(a, b) => c").unwrap(), @r###"
+        Lam {
+            args: [
+                Ident(
+                    "a",
+                ),
+                Ident(
+                    "b",
+                ),
+            ],
+            body: Ident {
+                name: "c",
+            },
+            is_async: false,
+        }
+        "###);
     }
 
     #[test]
     fn fn_returning_num_literal() {
-        assert_eq!(parse("() => 10"), "Lam([], Lit(Num(\"10\")), false)");
+        insta::assert_debug_snapshot!(parser().parse("() => 10").unwrap(), @r###"
+        Lam {
+            args: [],
+            body: Lit {
+                literal: Num(
+                    "10",
+                ),
+            },
+            is_async: false,
+        }
+        "###);
     }
 
     #[test]
     fn fn_returning_str_literal() {
-        assert_eq!(
-            parse("(a) => \"hello\""),
-            "Lam([Ident(\"a\")], Lit(Str(\"hello\")), false)"
-        );
+        insta::assert_debug_snapshot!(parser().parse("(a) => \"hello\"").unwrap(), @r###"
+        Lam {
+            args: [
+                Ident(
+                    "a",
+                ),
+            ],
+            body: Lit {
+                literal: Str(
+                    "hello",
+                ),
+            },
+            is_async: false,
+        }
+        "###);
     }
 
     #[test]
     fn app_with_no_args() {
-        assert_eq!(parse("foo()"), "App(Ident(\"foo\"), [])");
+        insta::assert_debug_snapshot!(parser().parse("foo()").unwrap(), @r###"
+        App {
+            lam: Ident {
+                name: "foo",
+            },
+            args: [],
+        }
+        "###);
     }
 
     #[test]
     fn app_with_multiple_args() {
-        assert_eq!(
-            parse("foo(a, b)"),
-            "App(Ident(\"foo\"), [Ident(\"a\"), Ident(\"b\")])"
-        );
+        insta::assert_debug_snapshot!(parser().parse("foo(a, b)").unwrap(), @r###"
+        App {
+            lam: Ident {
+                name: "foo",
+            },
+            args: [
+                Ident {
+                    name: "a",
+                },
+                Ident {
+                    name: "b",
+                },
+            ],
+        }
+        "###);
     }
 
     #[test]
     fn app_with_multiple_lit_args() {
-        assert_eq!(
-            parse("foo(10, \"hello\")"),
-            "App(Ident(\"foo\"), [Lit(Num(\"10\")), Lit(Str(\"hello\"))])"
-        );
+        insta::assert_debug_snapshot!(parser().parse("foo(10, \"hello\")").unwrap(), @r###"
+        App {
+            lam: Ident {
+                name: "foo",
+            },
+            args: [
+                Lit {
+                    literal: Num(
+                        "10",
+                    ),
+                },
+                Lit {
+                    literal: Str(
+                        "hello",
+                    ),
+                },
+            ],
+        }
+        "###);
     }
 
     #[test]
     fn atom_number() {
-        assert_eq!(parse("10"), "Lit(Num(\"10\"))");
+        insta::assert_debug_snapshot!(parser().parse("10").unwrap(), @r###"
+        Lit {
+            literal: Num(
+                "10",
+            ),
+        }
+        "###);
     }
 
     #[test]
     fn atom_string() {
-        assert_eq!(parse("\"hello\""), "Lit(Str(\"hello\"))");
+        insta::assert_debug_snapshot!(parser().parse("\"hello\"").unwrap(), @r###"
+        Lit {
+            literal: Str(
+                "hello",
+            ),
+        }
+        "###);
     }
 
     #[test]
     fn simple_let() {
-        assert_eq!(
-            parse("let x = 5 in x"),
-            "Let(Ident(\"x\"), Lit(Num(\"5\")), Ident(\"x\"))"
-        );
+        insta::assert_debug_snapshot!(parser().parse("let x = 5 in x").unwrap(), @r###"
+        Let {
+            pattern: Ident(
+                "x",
+            ),
+            value: Lit {
+                literal: Num(
+                    "5",
+                ),
+            },
+            body: Ident {
+                name: "x",
+            },
+        }
+        "###);
     }
 
     #[test]
     fn nested_let() {
-        assert_eq!(
-            parse("let x = 5 in let y = 10 in z"),
-            "Let(Ident(\"x\"), Lit(Num(\"5\")), Let(Ident(\"y\"), Lit(Num(\"10\")), Ident(\"z\")))",
-        );
+        insta::assert_debug_snapshot!(parser().parse("let x = 5 in let y = 10 in x + y").unwrap(), @r###"
+        Let {
+            pattern: Ident(
+                "x",
+            ),
+            value: Lit {
+                literal: Num(
+                    "5",
+                ),
+            },
+            body: Let {
+                pattern: Ident(
+                    "y",
+                ),
+                value: Lit {
+                    literal: Num(
+                        "10",
+                    ),
+                },
+                body: Op {
+                    op: Add,
+                    left: Ident {
+                        name: "x",
+                    },
+                    right: Ident {
+                        name: "y",
+                    },
+                },
+            },
+        }
+        "###);
     }
 
     #[test]
     fn add_sub_operations() {
-        assert_eq!(
-            parse("1 + 2 - 3"),
-            "Op(Sub, Op(Add, Lit(Num(\"1\")), Lit(Num(\"2\"))), Lit(Num(\"3\")))",
-        );
+        insta::assert_debug_snapshot!(parser().parse("1 + 2 - 3").unwrap(), @r###"
+        Op {
+            op: Sub,
+            left: Op {
+                op: Add,
+                left: Lit {
+                    literal: Num(
+                        "1",
+                    ),
+                },
+                right: Lit {
+                    literal: Num(
+                        "2",
+                    ),
+                },
+            },
+            right: Lit {
+                literal: Num(
+                    "3",
+                ),
+            },
+        }
+        "###);
     }
 
     #[test]
     fn mul_div_operations() {
-        assert_eq!(
-            parse("x * y / z"),
-            "Op(Div, Op(Mul, Ident(\"x\"), Ident(\"y\")), Ident(\"z\"))",
-        );
+        insta::assert_debug_snapshot!(parser().parse("x * y / z").unwrap(), @r###"
+        Op {
+            op: Div,
+            left: Op {
+                op: Mul,
+                left: Ident {
+                    name: "x",
+                },
+                right: Ident {
+                    name: "y",
+                },
+            },
+            right: Ident {
+                name: "z",
+            },
+        }
+        "###);
     }
 
     #[test]
     fn operator_precedence() {
-        assert_eq!(
-            parse("a + b * c"),
-            "Op(Add, Ident(\"a\"), Op(Mul, Ident(\"b\"), Ident(\"c\")))",
-        );
+        insta::assert_debug_snapshot!(parser().parse("a + b * c").unwrap(), @r###"
+        Op {
+            op: Add,
+            left: Ident {
+                name: "a",
+            },
+            right: Op {
+                op: Mul,
+                left: Ident {
+                    name: "b",
+                },
+                right: Ident {
+                    name: "c",
+                },
+            },
+        }
+        "###);
     }
 
     #[test]
     fn specifying_operator_precedence_with_parens() {
-        assert_eq!(
-            parse("(a + b) * c"),
-            "Op(Mul, Op(Add, Ident(\"a\"), Ident(\"b\")), Ident(\"c\"))",
-        );
+        insta::assert_debug_snapshot!(parser().parse("(a + b) * c").unwrap(), @r###"
+        Op {
+            op: Mul,
+            left: Op {
+                op: Add,
+                left: Ident {
+                    name: "a",
+                },
+                right: Ident {
+                    name: "b",
+                },
+            },
+            right: Ident {
+                name: "c",
+            },
+        }
+        "###);
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -18,12 +18,31 @@ pub enum BinOp {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
-    App(Box<Expr>, Vec<Expr>),
-    Ident(String),
-    Lam(Vec<BindingIdent>, Box<Expr>, bool),
-    Let(Pattern, Box<Expr>, Box<Expr>),
-    Lit(Literal),
-    Op(BinOp, Box<Expr>, Box<Expr>),
+    App {
+        lam: Box<Expr>,
+        args: Vec<Expr>,
+    },
+    Ident {
+        name: String,
+    },
+    Lam {
+        args: Vec<BindingIdent>,
+        body: Box<Expr>,
+        is_async: bool,
+    },
+    Let {
+        pattern: Pattern,
+        value: Box<Expr>,
+        body: Box<Expr>,
+    },
+    Lit {
+        literal: Literal,
+    },
+    Op {
+        op: BinOp,
+        left: Box<Expr>,
+        right: Box<Expr>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -4,8 +4,8 @@ use super::literal::Literal;
 // let bindings
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BindingIdent {
-    Ident(String),
-    Rest(String),
+    Ident { name: String },
+    Rest { name: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -47,6 +47,6 @@ pub enum Expr {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
-    Ident(String),
+    Ident { name: String },
     // TODO: add more patterns later
 }


### PR DESCRIPTION
This is in preparation to add location information to the AST produced the by the parser.  This PR also introduces snapshot testing.