### PR TITLE
[parser]: Add location span data to parsed AST

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -87,9 +87,9 @@ where
 }
 
 use crate::context::{Context, Env};
-use crate::syntax::{BindingIdent, Expr, Pattern};
+use crate::syntax::{BindingIdent, Expr, ExprWithSpan, Pattern, PatternWithSpan};
 
-pub fn infer_expr(env: Env, expr: &Expr) -> Scheme {
+pub fn infer_expr(env: Env, expr: &ExprWithSpan) -> Scheme {
     let init_ctx = Context::from(env);
     let (ty, cs) = infer(expr, &init_ctx);
     let subs = run_solve(&cs, &init_ctx);
@@ -111,13 +111,13 @@ fn generalize(env: &Env, ty: &Type) -> Scheme {
 
 type InferResult = (Type, Vec<Constraint>);
 
-fn infer(expr: &Expr, ctx: &Context) -> InferResult {
+fn infer(expr: &ExprWithSpan, ctx: &Context) -> InferResult {
     match expr {
-        Expr::Ident { name } => {
+        (Expr::Ident { name }, _) => {
             let ty = ctx.lookup_env(name);
             (ty, vec![])
         }
-        Expr::App { lam, args } => {
+        (Expr::App { lam, args }, _) => {
             let (t_fn, cs_fn) = infer(lam, ctx);
             let (t_args, cs_args) = infer_many(args, ctx);
             let tv = ctx.fresh();
@@ -137,7 +137,7 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (Type::from(tv), constraints)
         }
-        Expr::Lam { args, body, .. } => {
+        (Expr::Lam { args, body, .. }, _) => {
             // Creates a new type variable for each arg
             let arg_tvs: Vec<_> = args.iter().map(|_| Type::Var(ctx.fresh())).collect();
             let mut new_ctx = ctx.clone();
@@ -147,8 +147,12 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
                     ty: tv.clone(),
                 };
                 match arg {
-                    BindingIdent::Ident { name } => new_ctx.env.insert(name.to_string(), scheme),
-                    BindingIdent::Rest { name } => new_ctx.env.insert(name.to_string(), scheme),
+                    (BindingIdent::Ident { name }, _) => {
+                        new_ctx.env.insert(name.to_string(), scheme)
+                    }
+                    (BindingIdent::Rest { name }, _) => {
+                        new_ctx.env.insert(name.to_string(), scheme)
+                    }
                 };
             }
             let (ret_ty, cs) = infer(body, &new_ctx);
@@ -159,11 +163,14 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (lam_ty, cs)
         }
-        Expr::Let {
-            pattern,
-            value,
-            body,
-        } => {
+        (
+            Expr::Let {
+                pattern,
+                value,
+                body,
+            },
+            _,
+        ) => {
             let (t1, cs1) = infer(&value, &ctx);
             let subs = run_solve(&cs1, &ctx);
             let (new_ctx, new_cs) = infer_pattern(pattern, &t1, &subs, ctx);
@@ -176,9 +183,9 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 
             (t2.apply(&subs), vec![])
         }
-        Expr::Lit { literal } => (Type::from(literal), vec![]),
+        (Expr::Lit { literal }, _) => (Type::from(literal), vec![]),
         // TODO: check the `op` field when we introduce comparison operators
-        Expr::Op { left, right, .. } => {
+        (Expr::Op { left, right, .. }, _) => {
             let left = Box::as_ref(left);
             let right = Box::as_ref(right);
             let (ts, cs) = infer_many(&[left.clone(), right.clone()], ctx);
@@ -205,7 +212,7 @@ fn infer(expr: &Expr, ctx: &Context) -> InferResult {
 }
 
 fn infer_pattern(
-    pattern: &Pattern,
+    pattern: &PatternWithSpan,
     ty: &Type,
     subs: &Subst,
     ctx: &Context,
@@ -213,7 +220,7 @@ fn infer_pattern(
     let scheme = generalize(&ctx.env.apply(subs), &ty.apply(subs));
 
     match pattern {
-        Pattern::Ident { name } => {
+        (Pattern::Ident { name }, _) => {
             let mut new_ctx = ctx.clone();
             new_ctx.env.insert(name.to_owned(), scheme);
 
@@ -222,7 +229,7 @@ fn infer_pattern(
     }
 }
 
-fn infer_many(exprs: &[Expr], ctx: &Context) -> (Vec<Type>, Vec<Constraint>) {
+fn infer_many(exprs: &[ExprWithSpan], ctx: &Context) -> (Vec<Type>, Vec<Constraint>) {
     let mut ts: Vec<Type> = Vec::new();
     let mut all_cs: Vec<Constraint> = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,33 +8,12 @@ use nouveau_lib::infer::*;
 fn main() {
     println!("Hello, world!");
 
-    // let t = Type::Lam(TLam {
-    //     args: vec![Type::Prim(Primitive::Num)],
-    //     ret: Box::new(Type::Prim(Primitive::Num)),
-    // });
-
-    // if let Type::Lam(TLam { args, .. }) = &t {
-    //     println!("t is a lambad and it takes {} args", args.len());
-    // }
-
-    // println!("t = {:?}", &t);
-
-    // let expr = Expr::Lam(
-    //     vec![BindingIdent::Ident(String::from("x"))],
-    //     // TODO: add helpers like Lit::from(5.0), Lit::from("hello"), etc.
-    //     Box::new(Expr::Lit(Literal::Num(String::from("5.0")))),
-    //     false,
-    // );
-
-    // let sub = HashMap::new();
-    // t.apply(&sub);
-    // t.apply(&sub);
-
-    // println!("expr = {:?}", &expr);
-
     let env: Env = HashMap::new();
     let expr = parser().parse("5 + 10").unwrap();
     let result = infer_expr(env, &expr);
 
-    assert_eq!(format!("{}", result), "5");
+    assert_eq!(format!("{}", result), "number");
+
+    let ast = parser().parse("let x = 5 in x").unwrap();
+    println!("ast = {:?}", ast);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,14 +1,21 @@
 use chumsky::prelude::*;
 
 use super::literal::Literal;
-use super::syntax::{BinOp, BindingIdent, Expr, Pattern};
+use super::syntax::{BinOp, BindingIdent, Expr, ExprWithSpan, Pattern};
 
-pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
+pub type Span = std::ops::Range<usize>;
+
+pub fn parser() -> impl Parser<char, ExprWithSpan, Error = Simple<char>> {
     let ident = text::ident().padded();
 
     let num = text::int(10)
-        .map_with_span(|s, _| Expr::Lit {
-            literal: Literal::Num(s),
+        .map_with_span(|s, span: Span| {
+            (
+                Expr::Lit {
+                    literal: Literal::Num(s),
+                },
+                span,
+            )
         })
         .padded();
 
@@ -16,8 +23,13 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
         .ignore_then(filter(|c| *c != '"').repeated())
         .then_ignore(just('"'))
         .collect::<String>()
-        .map_with_span(|s, _| Expr::Lit {
-            literal: Literal::Str(s),
+        .map_with_span(|s, span| {
+            (
+                Expr::Lit {
+                    literal: Literal::Str(s),
+                },
+                span,
+            )
         });
 
     let lit = num.or(str_);
@@ -25,7 +37,7 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
     let expr = recursive(|expr| {
         let atom = num
             .or(expr.clone().delimited_by(just("("), just(")")))
-            .or(ident.map_with_span(|name, _| Expr::Ident { name }))
+            .or(ident.map_with_span(|name, span| (Expr::Ident { name }, span)))
             .or(lit);
 
         let product = atom
@@ -38,10 +50,18 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
                 .then(atom.clone())
                 .repeated(),
             )
-            .foldl(|left, (op, right)| Expr::Op {
-                op,
-                left: Box::from(left),
-                right: Box::from(right),
+            .foldl(|left, (op, right)| {
+                let span = left.1.start..right.1.end;
+                {
+                    (
+                        Expr::Op {
+                            op,
+                            left: Box::from(left),
+                            right: Box::from(right),
+                        },
+                        span,
+                    )
+                }
             });
 
         let sum = product
@@ -54,10 +74,18 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
                 .then(product.clone())
                 .repeated(),
             )
-            .foldl(|left, (op, right)| Expr::Op {
-                op,
-                left: Box::from(left),
-                right: Box::from(right),
+            .foldl(|left, (op, right)| {
+                let span = left.1.start..right.1.end;
+                {
+                    (
+                        Expr::Op {
+                            op,
+                            left: Box::from(left),
+                            right: Box::from(right),
+                        },
+                        span,
+                    )
+                }
             });
 
         let app = atom
@@ -69,13 +97,18 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
                     .allow_trailing()
                     .delimited_by(just("("), just(")")),
             )
-            .map_with_span(|(func, args), _| Expr::App {
-                lam: Box::new(func),
-                args,
+            .map_with_span(|(func, args), span| {
+                (
+                    Expr::App {
+                        lam: Box::new(func),
+                        args,
+                    },
+                    span,
+                )
             });
 
         let param_list = ident
-            .map_with_span(|name, _| BindingIdent::Ident { name })
+            .map_with_span(|name, span| (BindingIdent::Ident { name }, span))
             .padded()
             .separated_by(just(","))
             .allow_trailing()
@@ -84,22 +117,32 @@ pub fn parser() -> impl Parser<char, Expr, Error = Simple<char>> {
         let lam = param_list
             .then_ignore(just("=>").padded())
             .then(expr.clone())
-            .map_with_span(|(args, body), _| Expr::Lam {
-                args,
-                body: Box::new(body),
-                is_async: false,
+            .map_with_span(|(args, body), span| {
+                (
+                    Expr::Lam {
+                        args,
+                        body: Box::new(body),
+                        is_async: false,
+                    },
+                    span,
+                )
             });
 
         let r#let = just("let")
-            .ignore_then(ident)
+            .ignore_then(ident.map_with_span(|name, span| (Pattern::Ident { name }, span)))
             .then_ignore(just("=").padded())
             .then(expr.clone())
             .then_ignore(just("in").padded())
             .then(expr.clone())
-            .map_with_span(|((name, value), body), _| Expr::Let {
-                pattern: Pattern::Ident { name },
-                value: Box::new(value),
-                body: Box::new(body),
+            .map_with_span(|((pattern, value), body), span| {
+                (
+                    Expr::Let {
+                        pattern,
+                        value: Box::new(value),
+                        body: Box::new(body),
+                    },
+                    span,
+                )
             });
 
         app.or(lam).or(r#let).or(sum)
@@ -115,274 +158,441 @@ mod tests {
     #[test]
     fn fn_with_multiple_params() {
         insta::assert_debug_snapshot!(parser().parse("(a, b) => c").unwrap(), @r###"
-        Lam {
-            args: [
-                Ident {
-                    name: "a",
-                },
-                Ident {
-                    name: "b",
-                },
-            ],
-            body: Ident {
-                name: "c",
+        (
+            Lam {
+                args: [
+                    (
+                        Ident {
+                            name: "a",
+                        },
+                        1..2,
+                    ),
+                    (
+                        Ident {
+                            name: "b",
+                        },
+                        4..5,
+                    ),
+                ],
+                body: (
+                    Ident {
+                        name: "c",
+                    },
+                    10..11,
+                ),
+                is_async: false,
             },
-            is_async: false,
-        }
+            0..11,
+        )
         "###);
     }
 
     #[test]
     fn fn_returning_num_literal() {
         insta::assert_debug_snapshot!(parser().parse("() => 10").unwrap(), @r###"
-        Lam {
-            args: [],
-            body: Lit {
-                literal: Num(
-                    "10",
+        (
+            Lam {
+                args: [],
+                body: (
+                    Lit {
+                        literal: Num(
+                            "10",
+                        ),
+                    },
+                    6..8,
                 ),
+                is_async: false,
             },
-            is_async: false,
-        }
+            0..8,
+        )
         "###);
     }
 
     #[test]
     fn fn_returning_str_literal() {
         insta::assert_debug_snapshot!(parser().parse("(a) => \"hello\"").unwrap(), @r###"
-        Lam {
-            args: [
-                Ident {
-                    name: "a",
-                },
-            ],
-            body: Lit {
-                literal: Str(
-                    "hello",
+        (
+            Lam {
+                args: [
+                    (
+                        Ident {
+                            name: "a",
+                        },
+                        1..2,
+                    ),
+                ],
+                body: (
+                    Lit {
+                        literal: Str(
+                            "hello",
+                        ),
+                    },
+                    7..14,
                 ),
+                is_async: false,
             },
-            is_async: false,
-        }
+            0..14,
+        )
         "###);
     }
 
     #[test]
     fn app_with_no_args() {
         insta::assert_debug_snapshot!(parser().parse("foo()").unwrap(), @r###"
-        App {
-            lam: Ident {
-                name: "foo",
+        (
+            App {
+                lam: (
+                    Ident {
+                        name: "foo",
+                    },
+                    0..3,
+                ),
+                args: [],
             },
-            args: [],
-        }
+            0..5,
+        )
         "###);
     }
 
     #[test]
     fn app_with_multiple_args() {
         insta::assert_debug_snapshot!(parser().parse("foo(a, b)").unwrap(), @r###"
-        App {
-            lam: Ident {
-                name: "foo",
+        (
+            App {
+                lam: (
+                    Ident {
+                        name: "foo",
+                    },
+                    0..3,
+                ),
+                args: [
+                    (
+                        Ident {
+                            name: "a",
+                        },
+                        4..5,
+                    ),
+                    (
+                        Ident {
+                            name: "b",
+                        },
+                        7..8,
+                    ),
+                ],
             },
-            args: [
-                Ident {
-                    name: "a",
-                },
-                Ident {
-                    name: "b",
-                },
-            ],
-        }
+            0..9,
+        )
         "###);
     }
 
     #[test]
     fn app_with_multiple_lit_args() {
         insta::assert_debug_snapshot!(parser().parse("foo(10, \"hello\")").unwrap(), @r###"
-        App {
-            lam: Ident {
-                name: "foo",
+        (
+            App {
+                lam: (
+                    Ident {
+                        name: "foo",
+                    },
+                    0..3,
+                ),
+                args: [
+                    (
+                        Lit {
+                            literal: Num(
+                                "10",
+                            ),
+                        },
+                        4..6,
+                    ),
+                    (
+                        Lit {
+                            literal: Str(
+                                "hello",
+                            ),
+                        },
+                        8..15,
+                    ),
+                ],
             },
-            args: [
-                Lit {
-                    literal: Num(
-                        "10",
-                    ),
-                },
-                Lit {
-                    literal: Str(
-                        "hello",
-                    ),
-                },
-            ],
-        }
+            0..16,
+        )
         "###);
     }
 
     #[test]
     fn atom_number() {
         insta::assert_debug_snapshot!(parser().parse("10").unwrap(), @r###"
-        Lit {
-            literal: Num(
-                "10",
-            ),
-        }
+        (
+            Lit {
+                literal: Num(
+                    "10",
+                ),
+            },
+            0..2,
+        )
         "###);
     }
 
     #[test]
     fn atom_string() {
         insta::assert_debug_snapshot!(parser().parse("\"hello\"").unwrap(), @r###"
-        Lit {
-            literal: Str(
-                "hello",
-            ),
-        }
+        (
+            Lit {
+                literal: Str(
+                    "hello",
+                ),
+            },
+            0..7,
+        )
         "###);
     }
 
     #[test]
     fn simple_let() {
+        // TODO: don't include whitespace and the '=' in the span for 'x'
         insta::assert_debug_snapshot!(parser().parse("let x = 5 in x").unwrap(), @r###"
-        Let {
-            pattern: Ident {
-                name: "x",
-            },
-            value: Lit {
-                literal: Num(
-                    "5",
+        (
+            Let {
+                pattern: (
+                    Ident {
+                        name: "x",
+                    },
+                    3..6,
+                ),
+                value: (
+                    Lit {
+                        literal: Num(
+                            "5",
+                        ),
+                    },
+                    8..9,
+                ),
+                body: (
+                    Ident {
+                        name: "x",
+                    },
+                    13..14,
                 ),
             },
-            body: Ident {
-                name: "x",
-            },
-        }
+            0..14,
+        )
         "###);
     }
 
     #[test]
     fn nested_let() {
+        // TODO: don't include whitespace and the '=' in the span of the patterns
         insta::assert_debug_snapshot!(parser().parse("let x = 5 in let y = 10 in x + y").unwrap(), @r###"
-        Let {
-            pattern: Ident {
-                name: "x",
-            },
-            value: Lit {
-                literal: Num(
-                    "5",
-                ),
-            },
-            body: Let {
-                pattern: Ident {
-                    name: "y",
-                },
-                value: Lit {
-                    literal: Num(
-                        "10",
-                    ),
-                },
-                body: Op {
-                    op: Add,
-                    left: Ident {
+        (
+            Let {
+                pattern: (
+                    Ident {
                         name: "x",
                     },
-                    right: Ident {
-                        name: "y",
+                    3..6,
+                ),
+                value: (
+                    Lit {
+                        literal: Num(
+                            "5",
+                        ),
                     },
-                },
+                    8..9,
+                ),
+                body: (
+                    Let {
+                        pattern: (
+                            Ident {
+                                name: "y",
+                            },
+                            16..19,
+                        ),
+                        value: (
+                            Lit {
+                                literal: Num(
+                                    "10",
+                                ),
+                            },
+                            21..23,
+                        ),
+                        body: (
+                            Op {
+                                op: Add,
+                                left: (
+                                    Ident {
+                                        name: "x",
+                                    },
+                                    27..29,
+                                ),
+                                right: (
+                                    Ident {
+                                        name: "y",
+                                    },
+                                    31..32,
+                                ),
+                            },
+                            27..32,
+                        ),
+                    },
+                    13..32,
+                ),
             },
-        }
+            0..32,
+        )
         "###);
     }
 
     #[test]
     fn add_sub_operations() {
         insta::assert_debug_snapshot!(parser().parse("1 + 2 - 3").unwrap(), @r###"
-        Op {
-            op: Sub,
-            left: Op {
-                op: Add,
-                left: Lit {
-                    literal: Num(
-                        "1",
-                    ),
-                },
-                right: Lit {
-                    literal: Num(
-                        "2",
-                    ),
-                },
-            },
-            right: Lit {
-                literal: Num(
-                    "3",
+        (
+            Op {
+                op: Sub,
+                left: (
+                    Op {
+                        op: Add,
+                        left: (
+                            Lit {
+                                literal: Num(
+                                    "1",
+                                ),
+                            },
+                            0..1,
+                        ),
+                        right: (
+                            Lit {
+                                literal: Num(
+                                    "2",
+                                ),
+                            },
+                            4..5,
+                        ),
+                    },
+                    0..5,
+                ),
+                right: (
+                    Lit {
+                        literal: Num(
+                            "3",
+                        ),
+                    },
+                    8..9,
                 ),
             },
-        }
+            0..9,
+        )
         "###);
     }
 
     #[test]
     fn mul_div_operations() {
+        // TODO: don't include trailing whitespace in identifiers
         insta::assert_debug_snapshot!(parser().parse("x * y / z").unwrap(), @r###"
-        Op {
-            op: Div,
-            left: Op {
-                op: Mul,
-                left: Ident {
-                    name: "x",
-                },
-                right: Ident {
-                    name: "y",
-                },
+        (
+            Op {
+                op: Div,
+                left: (
+                    Op {
+                        op: Mul,
+                        left: (
+                            Ident {
+                                name: "x",
+                            },
+                            0..2,
+                        ),
+                        right: (
+                            Ident {
+                                name: "y",
+                            },
+                            4..6,
+                        ),
+                    },
+                    0..6,
+                ),
+                right: (
+                    Ident {
+                        name: "z",
+                    },
+                    8..9,
+                ),
             },
-            right: Ident {
-                name: "z",
-            },
-        }
+            0..9,
+        )
         "###);
     }
 
     #[test]
     fn operator_precedence() {
+        // TODO: don't include trailing whitespace in identifiers
         insta::assert_debug_snapshot!(parser().parse("a + b * c").unwrap(), @r###"
-        Op {
-            op: Add,
-            left: Ident {
-                name: "a",
+        (
+            Op {
+                op: Add,
+                left: (
+                    Ident {
+                        name: "a",
+                    },
+                    0..2,
+                ),
+                right: (
+                    Op {
+                        op: Mul,
+                        left: (
+                            Ident {
+                                name: "b",
+                            },
+                            4..6,
+                        ),
+                        right: (
+                            Ident {
+                                name: "c",
+                            },
+                            8..9,
+                        ),
+                    },
+                    4..9,
+                ),
             },
-            right: Op {
-                op: Mul,
-                left: Ident {
-                    name: "b",
-                },
-                right: Ident {
-                    name: "c",
-                },
-            },
-        }
+            0..9,
+        )
         "###);
     }
 
     #[test]
     fn specifying_operator_precedence_with_parens() {
+        // TODO: don't include trailing whitespace in identifiers
         insta::assert_debug_snapshot!(parser().parse("(a + b) * c").unwrap(), @r###"
-        Op {
-            op: Mul,
-            left: Op {
-                op: Add,
-                left: Ident {
-                    name: "a",
-                },
-                right: Ident {
-                    name: "b",
-                },
+        (
+            Op {
+                op: Mul,
+                left: (
+                    Op {
+                        op: Add,
+                        left: (
+                            Ident {
+                                name: "a",
+                            },
+                            1..3,
+                        ),
+                        right: (
+                            Ident {
+                                name: "b",
+                            },
+                            5..6,
+                        ),
+                    },
+                    1..6,
+                ),
+                right: (
+                    Ident {
+                        name: "c",
+                    },
+                    10..11,
+                ),
             },
-            right: Ident {
-                name: "c",
-            },
-        }
+            1..11,
+        )
         "###);
     }
 }

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,5 +1,7 @@
 use super::literal::Literal;
 
+pub type Span = std::ops::Range<usize>;
+
 // TODO: rename this to something else since we can't use it
 // let bindings
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -7,6 +9,8 @@ pub enum BindingIdent {
     Ident { name: String },
     Rest { name: String },
 }
+
+pub type BindingIdentWithSpan = (BindingIdent, Span);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinOp {
@@ -19,34 +23,38 @@ pub enum BinOp {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     App {
-        lam: Box<Expr>,
-        args: Vec<Expr>,
+        lam: Box<ExprWithSpan>,
+        args: Vec<ExprWithSpan>,
     },
     Ident {
         name: String,
     },
     Lam {
-        args: Vec<BindingIdent>,
-        body: Box<Expr>,
+        args: Vec<BindingIdentWithSpan>,
+        body: Box<ExprWithSpan>,
         is_async: bool,
     },
     Let {
-        pattern: Pattern,
-        value: Box<Expr>,
-        body: Box<Expr>,
+        pattern: PatternWithSpan,
+        value: Box<ExprWithSpan>,
+        body: Box<ExprWithSpan>,
     },
     Lit {
         literal: Literal,
     },
     Op {
         op: BinOp,
-        left: Box<Expr>,
-        right: Box<Expr>,
+        left: Box<ExprWithSpan>,
+        right: Box<ExprWithSpan>,
     },
 }
+
+pub type ExprWithSpan = (Expr, Span);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Pattern {
     Ident { name: String },
     // TODO: add more patterns later
 }
+
+pub type PatternWithSpan = (Pattern, Span);


### PR DESCRIPTION
This PR modifies the parser to return a pair where the second element is the span.

TODOs:
-  [x] don't include trailing whitespace in identifiers
-  [x] don't include '=' in the span of the pattern in `Let` nodes (we weren't actually including the '=', but instead including both leading and trailing whitespace)