### PR TITLE
Program parser

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -10,7 +10,12 @@ pub fn codegen_prog(prog: &Program) -> String {
         .iter()
         .map(|child| match child {
             (Statement::Decl { pattern, value }, _) => {
-                format!("let {} = {}", codegen_pattern(pattern), codegen_expr(value))
+                let pattern_output = codegen_pattern(pattern);
+                let value_output = codegen_expr(value);
+                match value {
+                    (Expr::Let {..}, _) => format!("var {} = {{\n{}\n}}", pattern_output, value_output),
+                    _ => format!("var {} = {}", pattern_output, value_output),
+                }
             }
             (Statement::Expr(expr), _) => codegen_expr(expr),
         })
@@ -57,9 +62,16 @@ pub fn codegen_expr(expr: &WithSpan<Expr>) -> String {
             // unique identifiers.
             let pattern = codegen_pattern(pattern);
             let value = codegen_expr(value);
-            let body = codegen_expr(body);
+            let body_output = codegen_expr(body);
 
-            format!("var {} = {};\n{}", pattern, value, body)
+            // TODO: introduce a JavaScript AST that we can use as an intermediary step before
+            // outputting a string.
+            // NOTE: let-in is essentially a linked list so we could have a helper function that
+            // converts that to a vector first.
+            match body.as_ref() {
+                (Expr::Let { .. }, _) => format!("var {} = {};\n{}", pattern, value, body_output),
+                _ => format!("var {} = {};\nreturn {};", pattern, value, body_output),
+            }
         }
         (Expr::Lit { literal }, _) => {
             format!("{}", literal)

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -5,6 +5,20 @@ use super::syntax::*;
 // TODO: refactor this to use an io writer
 
 #[allow(unstable_name_collisions)] // intersperse
+pub fn codegen_prog(prog: &Program) -> String {
+    prog.body
+        .iter()
+        .map(|child| match child {
+            (Statement::Decl { pattern, value }, _) => {
+                format!("let {} = {}", codegen_pattern(pattern), codegen_expr(value))
+            }
+            (Statement::Expr(expr), _) => codegen_expr(expr),
+        })
+        .intersperse(String::from("\n"))
+        .collect()
+}
+
+#[allow(unstable_name_collisions)] // intersperse
 pub fn codegen_expr(expr: &WithSpan<Expr>) -> String {
     match expr {
         (Expr::App { lam, args }, _) => {

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -5,7 +5,7 @@ use super::syntax::*;
 // TODO: refactor this to use an io writer
 
 #[allow(unstable_name_collisions)] // intersperse
-pub fn codegen_expr(expr: &ExprWithSpan) -> String {
+pub fn codegen_expr(expr: &WithSpan<Expr>) -> String {
     match expr {
         (Expr::App { lam, args }, _) => {
             let lam = codegen_expr(lam);
@@ -95,7 +95,7 @@ pub fn codegen_expr(expr: &ExprWithSpan) -> String {
     }
 }
 
-fn codegen_pattern(pattern: &PatternWithSpan) -> String {
+fn codegen_pattern(pattern: &WithSpan<Pattern>) -> String {
     match pattern {
         (Pattern::Ident { name }, _) => name.to_owned(),
     }

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -87,7 +87,14 @@ where
 }
 
 use crate::context::{Context, Env};
-use crate::syntax::{BindingIdent, Expr, WithSpan, Pattern};
+use crate::syntax::{BindingIdent, Expr, WithSpan, Pattern, Statement};
+
+pub fn infer_stmt(env: Env, stmt: &WithSpan<Statement>) -> Scheme {
+    match stmt {
+        (Statement::Expr(e), _) => infer_expr(env, e),
+        _ => panic!("We can't infer decls yet"),
+    }
+}
 
 pub fn infer_expr(env: Env, expr: &WithSpan<Expr>) -> Scheme {
     let init_ctx = Context::from(env);

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -87,9 +87,9 @@ where
 }
 
 use crate::context::{Context, Env};
-use crate::syntax::{BindingIdent, Expr, ExprWithSpan, Pattern, PatternWithSpan};
+use crate::syntax::{BindingIdent, Expr, WithSpan, Pattern};
 
-pub fn infer_expr(env: Env, expr: &ExprWithSpan) -> Scheme {
+pub fn infer_expr(env: Env, expr: &WithSpan<Expr>) -> Scheme {
     let init_ctx = Context::from(env);
     let (ty, cs) = infer(expr, &init_ctx);
     let subs = run_solve(&cs, &init_ctx);
@@ -111,7 +111,7 @@ fn generalize(env: &Env, ty: &Type) -> Scheme {
 
 type InferResult = (Type, Vec<Constraint>);
 
-fn infer(expr: &ExprWithSpan, ctx: &Context) -> InferResult {
+fn infer(expr: &WithSpan<Expr>, ctx: &Context) -> InferResult {
     match expr {
         (Expr::Ident { name }, _) => {
             let ty = ctx.lookup_env(name);
@@ -212,7 +212,7 @@ fn infer(expr: &ExprWithSpan, ctx: &Context) -> InferResult {
 }
 
 fn infer_pattern(
-    pattern: &PatternWithSpan,
+    pattern: &WithSpan<Pattern>,
     ty: &Type,
     subs: &Subst,
     ctx: &Context,
@@ -229,7 +229,7 @@ fn infer_pattern(
     }
 }
 
-fn infer_many(exprs: &[ExprWithSpan], ctx: &Context) -> (Vec<Type>, Vec<Constraint>) {
+fn infer_many(exprs: &[WithSpan<Expr>], ctx: &Context) -> (Vec<Type>, Vec<Constraint>) {
     let mut ts: Vec<Type> = Vec::new();
     let mut all_cs: Vec<Constraint> = Vec::new();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ fn main() {
     println!("Hello, world!");
 
     let env: Env = HashMap::new();
-    let expr = parser().parse("5 + 10").unwrap();
-    let result = infer_expr(env, &expr);
+    let prog = parser().parse("5 + 10").unwrap();
+    let stmt = prog.body.get(0).unwrap();
+    let result = infer_stmt(env, &stmt);
 
     assert_eq!(format!("{}", result), "number");
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -943,4 +943,50 @@ mod tests {
         }
         "###);
     }
+
+    #[test]
+    fn simple_let_inside_decl() {
+        insta::assert_debug_snapshot!(parser().parse("let foo = let x = 5 in x").unwrap(), @r###"
+        Program {
+            body: [
+                (
+                    Decl {
+                        pattern: (
+                            Ident {
+                                name: "foo",
+                            },
+                            4..7,
+                        ),
+                        value: (
+                            Let {
+                                pattern: (
+                                    Ident {
+                                        name: "x",
+                                    },
+                                    14..15,
+                                ),
+                                value: (
+                                    Lit {
+                                        literal: Num(
+                                            "5",
+                                        ),
+                                    },
+                                    18..19,
+                                ),
+                                body: (
+                                    Ident {
+                                        name: "x",
+                                    },
+                                    23..24,
+                                ),
+                            },
+                            10..24,
+                        ),
+                    },
+                    0..24,
+                ),
+            ],
+        }
+        "###);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,164 +1,13 @@
 use chumsky::prelude::*;
 
 use super::literal::Literal;
-use super::syntax::{BinOp, BindingIdent, Expr, Pattern, Program, Statement, WithSpan};
+use super::syntax::{BinOp, BindingIdent, Expr, Pattern, Program, Statement};
 
 pub type Span = std::ops::Range<usize>;
 
-pub fn parser() -> impl Parser<char, WithSpan<Expr>, Error = Simple<char>> {
-    let ident = text::ident();
+// TODO: add lexing layer so that it's easier to separate keywords and identifiers
 
-    let num = text::int(10)
-        .map_with_span(|s, span: Span| {
-            (
-                Expr::Lit {
-                    literal: Literal::Num(s),
-                },
-                span,
-            )
-        })
-        .padded();
-
-    let r#str = just("\"")
-        .ignore_then(filter(|c| *c != '"').repeated())
-        .then_ignore(just('"'))
-        .collect::<String>()
-        .map_with_span(|s, span| {
-            (
-                Expr::Lit {
-                    literal: Literal::Str(s),
-                },
-                span,
-            )
-        });
-
-    let lit = choice((num, r#str));
-
-    let expr = recursive(|expr| {
-        let atom = choice((
-            num,
-            expr.clone().delimited_by(just("("), just(")")),
-            ident.map_with_span(|name, span| (Expr::Ident { name }, span)),
-            lit,
-        ))
-        .padded();
-
-        let product = atom
-            .clone()
-            .then(
-                choice((
-                    just("*").padded().to(BinOp::Mul),
-                    just("/").padded().to(BinOp::Div),
-                ))
-                .then(atom.clone())
-                .repeated(),
-            )
-            .foldl(|left, (op, right)| {
-                let span = left.1.start..right.1.end;
-                {
-                    (
-                        Expr::Op {
-                            op,
-                            left: Box::from(left),
-                            right: Box::from(right),
-                        },
-                        span,
-                    )
-                }
-            });
-
-        let sum = product
-            .clone()
-            .then(
-                choice((
-                    just("+").padded().to(BinOp::Add),
-                    just("-").padded().to(BinOp::Sub),
-                ))
-                .then(product.clone())
-                .repeated(),
-            )
-            .foldl(|left, (op, right)| {
-                let span = left.1.start..right.1.end;
-                {
-                    (
-                        Expr::Op {
-                            op,
-                            left: Box::from(left),
-                            right: Box::from(right),
-                        },
-                        span,
-                    )
-                }
-            });
-
-        let app = atom
-            .clone()
-            .then(
-                expr.clone()
-                    .separated_by(just(","))
-                    .allow_trailing()
-                    .delimited_by(just("("), just(")")),
-            )
-            .map_with_span(|(func, args), span| {
-                (
-                    Expr::App {
-                        lam: Box::new(func),
-                        args,
-                    },
-                    span,
-                )
-            })
-            .padded();
-
-        let param_list = ident
-            .map_with_span(|name, span| (BindingIdent::Ident { name }, span))
-            .padded()
-            .separated_by(just(","))
-            .allow_trailing()
-            .delimited_by(just("("), just(")"));
-
-        let lam = param_list
-            .then_ignore(just("=>").padded())
-            .then(expr.clone())
-            .map_with_span(|(args, body), span| {
-                (
-                    Expr::Lam {
-                        args,
-                        body: Box::new(body),
-                        is_async: false,
-                    },
-                    span,
-                )
-            });
-
-        let r#let = just("let")
-            .ignore_then(
-                ident
-                    .map_with_span(|name, span| (Pattern::Ident { name }, span))
-                    .padded(),
-            )
-            .then_ignore(just("=").padded())
-            .then(expr.clone())
-            .then_ignore(just("in").padded())
-            .then(expr.clone())
-            .map_with_span(|((pattern, value), body), span| {
-                (
-                    Expr::Let {
-                        pattern,
-                        value: Box::new(value),
-                        body: Box::new(body),
-                    },
-                    span,
-                )
-            });
-
-        choice((app, lam, r#let, sum))
-    });
-
-    expr
-}
-
-pub fn program_parser() -> impl Parser<char, Program, Error = Simple<char>> {
+pub fn parser() -> impl Parser<char, Program, Error = Simple<char>> {
     let ident = text::ident();
 
     let num = text::int(10)
@@ -345,442 +194,554 @@ mod tests {
     #[test]
     fn fn_with_multiple_params() {
         insta::assert_debug_snapshot!(parser().parse("(a, b) => c").unwrap(), @r###"
-        (
-            Lam {
-                args: [
-                    (
-                        Ident {
-                            name: "a",
-                        },
-                        1..2,
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Lam {
+                                args: [
+                                    (
+                                        Ident {
+                                            name: "a",
+                                        },
+                                        1..2,
+                                    ),
+                                    (
+                                        Ident {
+                                            name: "b",
+                                        },
+                                        4..5,
+                                    ),
+                                ],
+                                body: (
+                                    Ident {
+                                        name: "c",
+                                    },
+                                    10..11,
+                                ),
+                                is_async: false,
+                            },
+                            0..11,
+                        ),
                     ),
-                    (
-                        Ident {
-                            name: "b",
-                        },
-                        4..5,
-                    ),
-                ],
-                body: (
-                    Ident {
-                        name: "c",
-                    },
-                    10..11,
+                    0..11,
                 ),
-                is_async: false,
-            },
-            0..11,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn fn_returning_num_literal() {
         insta::assert_debug_snapshot!(parser().parse("() => 10").unwrap(), @r###"
-        (
-            Lam {
-                args: [],
-                body: (
-                    Lit {
-                        literal: Num(
-                            "10",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Lam {
+                                args: [],
+                                body: (
+                                    Lit {
+                                        literal: Num(
+                                            "10",
+                                        ),
+                                    },
+                                    6..8,
+                                ),
+                                is_async: false,
+                            },
+                            0..8,
                         ),
-                    },
-                    6..8,
+                    ),
+                    0..8,
                 ),
-                is_async: false,
-            },
-            0..8,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn fn_returning_str_literal() {
         insta::assert_debug_snapshot!(parser().parse("(a) => \"hello\"").unwrap(), @r###"
-        (
-            Lam {
-                args: [
-                    (
-                        Ident {
-                            name: "a",
-                        },
-                        1..2,
-                    ),
-                ],
-                body: (
-                    Lit {
-                        literal: Str(
-                            "hello",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Lam {
+                                args: [
+                                    (
+                                        Ident {
+                                            name: "a",
+                                        },
+                                        1..2,
+                                    ),
+                                ],
+                                body: (
+                                    Lit {
+                                        literal: Str(
+                                            "hello",
+                                        ),
+                                    },
+                                    7..14,
+                                ),
+                                is_async: false,
+                            },
+                            0..14,
                         ),
-                    },
-                    7..14,
+                    ),
+                    0..14,
                 ),
-                is_async: false,
-            },
-            0..14,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn app_with_no_args() {
         insta::assert_debug_snapshot!(parser().parse("foo()").unwrap(), @r###"
-        (
-            App {
-                lam: (
-                    Ident {
-                        name: "foo",
-                    },
-                    0..3,
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            App {
+                                lam: (
+                                    Ident {
+                                        name: "foo",
+                                    },
+                                    0..3,
+                                ),
+                                args: [],
+                            },
+                            0..5,
+                        ),
+                    ),
+                    0..5,
                 ),
-                args: [],
-            },
-            0..5,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn app_with_multiple_args() {
         insta::assert_debug_snapshot!(parser().parse("foo(a, b)").unwrap(), @r###"
-        (
-            App {
-                lam: (
-                    Ident {
-                        name: "foo",
-                    },
-                    0..3,
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            App {
+                                lam: (
+                                    Ident {
+                                        name: "foo",
+                                    },
+                                    0..3,
+                                ),
+                                args: [
+                                    (
+                                        Ident {
+                                            name: "a",
+                                        },
+                                        4..5,
+                                    ),
+                                    (
+                                        Ident {
+                                            name: "b",
+                                        },
+                                        7..8,
+                                    ),
+                                ],
+                            },
+                            0..9,
+                        ),
+                    ),
+                    0..9,
                 ),
-                args: [
-                    (
-                        Ident {
-                            name: "a",
-                        },
-                        4..5,
-                    ),
-                    (
-                        Ident {
-                            name: "b",
-                        },
-                        7..8,
-                    ),
-                ],
-            },
-            0..9,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn app_with_multiple_lit_args() {
         insta::assert_debug_snapshot!(parser().parse("foo(10, \"hello\")").unwrap(), @r###"
-        (
-            App {
-                lam: (
-                    Ident {
-                        name: "foo",
-                    },
-                    0..3,
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            App {
+                                lam: (
+                                    Ident {
+                                        name: "foo",
+                                    },
+                                    0..3,
+                                ),
+                                args: [
+                                    (
+                                        Lit {
+                                            literal: Num(
+                                                "10",
+                                            ),
+                                        },
+                                        4..6,
+                                    ),
+                                    (
+                                        Lit {
+                                            literal: Str(
+                                                "hello",
+                                            ),
+                                        },
+                                        8..15,
+                                    ),
+                                ],
+                            },
+                            0..16,
+                        ),
+                    ),
+                    0..16,
                 ),
-                args: [
-                    (
-                        Lit {
-                            literal: Num(
-                                "10",
-                            ),
-                        },
-                        4..6,
-                    ),
-                    (
-                        Lit {
-                            literal: Str(
-                                "hello",
-                            ),
-                        },
-                        8..15,
-                    ),
-                ],
-            },
-            0..16,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn atom_number() {
         insta::assert_debug_snapshot!(parser().parse("10").unwrap(), @r###"
-        (
-            Lit {
-                literal: Num(
-                    "10",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Lit {
+                                literal: Num(
+                                    "10",
+                                ),
+                            },
+                            0..2,
+                        ),
+                    ),
+                    0..2,
                 ),
-            },
-            0..2,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn atom_string() {
         insta::assert_debug_snapshot!(parser().parse("\"hello\"").unwrap(), @r###"
-        (
-            Lit {
-                literal: Str(
-                    "hello",
-                ),
-            },
-            0..7,
-        )
-        "###);
-    }
-
-    #[test]
-    fn simple_let() {
-        insta::assert_debug_snapshot!(parser().parse("let x = 5 in x").unwrap(), @r###"
-        (
-            Let {
-                pattern: (
-                    Ident {
-                        name: "x",
-                    },
-                    4..5,
-                ),
-                value: (
-                    Lit {
-                        literal: Num(
-                            "5",
-                        ),
-                    },
-                    8..9,
-                ),
-                body: (
-                    Ident {
-                        name: "x",
-                    },
-                    13..14,
-                ),
-            },
-            0..14,
-        )
-        "###);
-    }
-
-    #[test]
-    fn nested_let() {
-        insta::assert_debug_snapshot!(parser().parse("let x = 5 in let y = 10 in x + y").unwrap(), @r###"
-        (
-            Let {
-                pattern: (
-                    Ident {
-                        name: "x",
-                    },
-                    4..5,
-                ),
-                value: (
-                    Lit {
-                        literal: Num(
-                            "5",
-                        ),
-                    },
-                    8..9,
-                ),
-                body: (
-                    Let {
-                        pattern: (
-                            Ident {
-                                name: "y",
-                            },
-                            17..18,
-                        ),
-                        value: (
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
                             Lit {
-                                literal: Num(
-                                    "10",
+                                literal: Str(
+                                    "hello",
                                 ),
                             },
-                            21..23,
+                            0..7,
                         ),
-                        body: (
-                            Op {
-                                op: Add,
-                                left: (
-                                    Ident {
-                                        name: "x",
-                                    },
-                                    27..28,
-                                ),
-                                right: (
-                                    Ident {
-                                        name: "y",
-                                    },
-                                    31..32,
-                                ),
-                            },
-                            27..32,
-                        ),
-                    },
-                    13..32,
+                    ),
+                    0..7,
                 ),
-            },
-            0..32,
-        )
+            ],
+        }
         "###);
     }
+
+    // TODO: this test should panic because we don't want to support let-in at the top level
+    // Right now the parser treats `in` as identifier instead of a keyword.
+    // #[test]
+    // fn simple_let() {
+    //     insta::assert_debug_snapshot!(parser().parse("let x = 5 in x").unwrap(), @r###"
+    //     (
+    //         Let {
+    //             pattern: (
+    //                 Ident {
+    //                     name: "x",
+    //                 },
+    //                 4..5,
+    //             ),
+    //             value: (
+    //                 Lit {
+    //                     literal: Num(
+    //                         "5",
+    //                     ),
+    //                 },
+    //                 8..9,
+    //             ),
+    //             body: (
+    //                 Ident {
+    //                     name: "x",
+    //                 },
+    //                 13..14,
+    //             ),
+    //         },
+    //         0..14,
+    //     )
+    //     "###);
+    // }
+
+    // TODO: this test should panic because we don't want to support let-in at the top level
+    // Right now the parser treats `in` as identifier instead of a keyword.
+    // #[test]
+    // fn nested_let() {
+    //     insta::assert_debug_snapshot!(parser().parse("let x = 5 in let y = 10 in x + y").unwrap(), @r###"
+    //     (
+    //         Let {
+    //             pattern: (
+    //                 Ident {
+    //                     name: "x",
+    //                 },
+    //                 4..5,
+    //             ),
+    //             value: (
+    //                 Lit {
+    //                     literal: Num(
+    //                         "5",
+    //                     ),
+    //                 },
+    //                 8..9,
+    //             ),
+    //             body: (
+    //                 Let {
+    //                     pattern: (
+    //                         Ident {
+    //                             name: "y",
+    //                         },
+    //                         17..18,
+    //                     ),
+    //                     value: (
+    //                         Lit {
+    //                             literal: Num(
+    //                                 "10",
+    //                             ),
+    //                         },
+    //                         21..23,
+    //                     ),
+    //                     body: (
+    //                         Op {
+    //                             op: Add,
+    //                             left: (
+    //                                 Ident {
+    //                                     name: "x",
+    //                                 },
+    //                                 27..28,
+    //                             ),
+    //                             right: (
+    //                                 Ident {
+    //                                     name: "y",
+    //                                 },
+    //                                 31..32,
+    //                             ),
+    //                         },
+    //                         27..32,
+    //                     ),
+    //                 },
+    //                 13..32,
+    //             ),
+    //         },
+    //         0..32,
+    //     )
+    //     "###);
+    // }
 
     #[test]
     fn add_sub_operations() {
         insta::assert_debug_snapshot!(parser().parse("1 + 2 - 3").unwrap(), @r###"
-        (
-            Op {
-                op: Sub,
-                left: (
-                    Op {
-                        op: Add,
-                        left: (
-                            Lit {
-                                literal: Num(
-                                    "1",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Op {
+                                op: Sub,
+                                left: (
+                                    Op {
+                                        op: Add,
+                                        left: (
+                                            Lit {
+                                                literal: Num(
+                                                    "1",
+                                                ),
+                                            },
+                                            0..1,
+                                        ),
+                                        right: (
+                                            Lit {
+                                                literal: Num(
+                                                    "2",
+                                                ),
+                                            },
+                                            4..5,
+                                        ),
+                                    },
+                                    0..5,
+                                ),
+                                right: (
+                                    Lit {
+                                        literal: Num(
+                                            "3",
+                                        ),
+                                    },
+                                    8..9,
                                 ),
                             },
-                            0..1,
+                            0..9,
                         ),
-                        right: (
-                            Lit {
-                                literal: Num(
-                                    "2",
-                                ),
-                            },
-                            4..5,
-                        ),
-                    },
-                    0..5,
+                    ),
+                    0..9,
                 ),
-                right: (
-                    Lit {
-                        literal: Num(
-                            "3",
-                        ),
-                    },
-                    8..9,
-                ),
-            },
-            0..9,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn mul_div_operations() {
         insta::assert_debug_snapshot!(parser().parse("x * y / z").unwrap(), @r###"
-        (
-            Op {
-                op: Div,
-                left: (
-                    Op {
-                        op: Mul,
-                        left: (
-                            Ident {
-                                name: "x",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Op {
+                                op: Div,
+                                left: (
+                                    Op {
+                                        op: Mul,
+                                        left: (
+                                            Ident {
+                                                name: "x",
+                                            },
+                                            0..1,
+                                        ),
+                                        right: (
+                                            Ident {
+                                                name: "y",
+                                            },
+                                            4..5,
+                                        ),
+                                    },
+                                    0..5,
+                                ),
+                                right: (
+                                    Ident {
+                                        name: "z",
+                                    },
+                                    8..9,
+                                ),
                             },
-                            0..1,
+                            0..9,
                         ),
-                        right: (
-                            Ident {
-                                name: "y",
-                            },
-                            4..5,
-                        ),
-                    },
-                    0..5,
+                    ),
+                    0..9,
                 ),
-                right: (
-                    Ident {
-                        name: "z",
-                    },
-                    8..9,
-                ),
-            },
-            0..9,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn operator_precedence() {
         insta::assert_debug_snapshot!(parser().parse("a + b * c").unwrap(), @r###"
-        (
-            Op {
-                op: Add,
-                left: (
-                    Ident {
-                        name: "a",
-                    },
-                    0..1,
-                ),
-                right: (
-                    Op {
-                        op: Mul,
-                        left: (
-                            Ident {
-                                name: "b",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Op {
+                                op: Add,
+                                left: (
+                                    Ident {
+                                        name: "a",
+                                    },
+                                    0..1,
+                                ),
+                                right: (
+                                    Op {
+                                        op: Mul,
+                                        left: (
+                                            Ident {
+                                                name: "b",
+                                            },
+                                            4..5,
+                                        ),
+                                        right: (
+                                            Ident {
+                                                name: "c",
+                                            },
+                                            8..9,
+                                        ),
+                                    },
+                                    4..9,
+                                ),
                             },
-                            4..5,
+                            0..9,
                         ),
-                        right: (
-                            Ident {
-                                name: "c",
-                            },
-                            8..9,
-                        ),
-                    },
-                    4..9,
+                    ),
+                    0..9,
                 ),
-            },
-            0..9,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn specifying_operator_precedence_with_parens() {
         insta::assert_debug_snapshot!(parser().parse("(a + b) * c").unwrap(), @r###"
-        (
-            Op {
-                op: Mul,
-                left: (
-                    Op {
-                        op: Add,
-                        left: (
-                            Ident {
-                                name: "a",
+        Program {
+            body: [
+                (
+                    Expr(
+                        (
+                            Op {
+                                op: Mul,
+                                left: (
+                                    Op {
+                                        op: Add,
+                                        left: (
+                                            Ident {
+                                                name: "a",
+                                            },
+                                            1..2,
+                                        ),
+                                        right: (
+                                            Ident {
+                                                name: "b",
+                                            },
+                                            5..6,
+                                        ),
+                                    },
+                                    1..6,
+                                ),
+                                right: (
+                                    Ident {
+                                        name: "c",
+                                    },
+                                    10..11,
+                                ),
                             },
-                            1..2,
+                            1..11,
                         ),
-                        right: (
-                            Ident {
-                                name: "b",
-                            },
-                            5..6,
-                        ),
-                    },
-                    1..6,
+                    ),
+                    0..11,
                 ),
-                right: (
-                    Ident {
-                        name: "c",
-                    },
-                    10..11,
-                ),
-            },
-            1..11,
-        )
+            ],
+        }
         "###);
     }
 
     #[test]
     fn single_decl() {
-        insta::assert_debug_snapshot!(program_parser().parse("let x = 5").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parser().parse("let x = 5").unwrap(), @r###"
         Program {
             body: [
                 (
@@ -809,7 +770,7 @@ mod tests {
 
     #[test]
     fn single_lambda_decl() {
-        insta::assert_debug_snapshot!(program_parser().parse("let x = (a, b) => a + b").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parser().parse("let x = (a, b) => a + b").unwrap(), @r###"
         Program {
             body: [
                 (
@@ -868,7 +829,7 @@ mod tests {
 
     #[test]
     fn multiple_decls() {
-        insta::assert_debug_snapshot!(program_parser().parse("let x = 5\nlet y = \"hello\"").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parser().parse("let x = 5\nlet y = \"hello\"").unwrap(), @r###"
         Program {
             body: [
                 (
@@ -916,7 +877,7 @@ mod tests {
 
     #[test]
     fn top_level_expr() {
-        insta::assert_debug_snapshot!(program_parser().parse("a + b").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parser().parse("a + b").unwrap(), @r###"
         Program {
             body: [
                 (
@@ -949,7 +910,7 @@ mod tests {
 
     #[test]
     fn multiple_top_level_expressions() {
-        insta::assert_debug_snapshot!(program_parser().parse("123\n\"hello\"").unwrap(), @r###"
+        insta::assert_debug_snapshot!(parser().parse("123\n\"hello\"").unwrap(), @r###"
         Program {
             body: [
                 (

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -2,6 +2,51 @@ use super::literal::Literal;
 
 pub type Span = std::ops::Range<usize>;
 
+pub type WithSpan<T> = (T, Span);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Program {
+    pub body: Vec<WithSpan<Statement>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Statement {
+    Decl {
+        pattern: WithSpan<Pattern>,
+        value: WithSpan<Expr>,
+    },
+    Expr(WithSpan<Expr>), // NOTE: does not include Expr::Let
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Expr {
+    App {
+        lam: Box<WithSpan<Expr>>,
+        args: Vec<WithSpan<Expr>>,
+    },
+    Ident {
+        name: String,
+    },
+    Lam {
+        args: Vec<WithSpan<BindingIdent>>,
+        body: Box<WithSpan<Expr>>,
+        is_async: bool,
+    },
+    Let {
+        pattern: WithSpan<Pattern>,
+        value: Box<WithSpan<Expr>>,
+        body: Box<WithSpan<Expr>>,
+    },
+    Lit {
+        literal: Literal,
+    },
+    Op {
+        op: BinOp,
+        left: Box<WithSpan<Expr>>,
+        right: Box<WithSpan<Expr>>,
+    },
+}
+
 // TODO: rename this to something else since we can't use it
 // let bindings
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,7 +55,11 @@ pub enum BindingIdent {
     Rest { name: String },
 }
 
-pub type BindingIdentWithSpan = (BindingIdent, Span);
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Pattern {
+    Ident { name: String },
+    // TODO: add more patterns later
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinOp {
@@ -19,42 +68,3 @@ pub enum BinOp {
     Mul,
     Div,
 }
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Expr {
-    App {
-        lam: Box<ExprWithSpan>,
-        args: Vec<ExprWithSpan>,
-    },
-    Ident {
-        name: String,
-    },
-    Lam {
-        args: Vec<BindingIdentWithSpan>,
-        body: Box<ExprWithSpan>,
-        is_async: bool,
-    },
-    Let {
-        pattern: PatternWithSpan,
-        value: Box<ExprWithSpan>,
-        body: Box<ExprWithSpan>,
-    },
-    Lit {
-        literal: Literal,
-    },
-    Op {
-        op: BinOp,
-        left: Box<ExprWithSpan>,
-        right: Box<ExprWithSpan>,
-    },
-}
-
-pub type ExprWithSpan = (Expr, Span);
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Pattern {
-    Ident { name: String },
-    // TODO: add more patterns later
-}
-
-pub type PatternWithSpan = (Pattern, Span);

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -19,6 +19,11 @@ use nouveau_lib::parser::parser;
 #[test_case("a / (b / c)", "a / (b / c)"; "division with parens")]
 #[test_case("a - b - c", "a - b - c"; "subtraction without parens")]
 #[test_case("a - (b - c)", "a - (b - c)"; "subtraction with parens")]
+#[test_case("let add = (a, b) => a + b", "var add = (a, b) => a + b"; "function declaration")]
+#[test_case("let five = 5", "var five = 5"; "variable declaration with literal value")]
+#[test_case("let foo = let x = 5 in x", "var foo = {\nvar x = 5;\nreturn x;\n}"; "let-in expression inside declaration")]
+#[test_case("let foo = let x = 5 in let y = 10 in x + y", "var foo = {\nvar x = 5;\nvar y = 10;\nreturn x + y;\n}"; "nested let-in expressions inside declaration")]
+// TODO: add a test case with multiple declarations
 fn parse_then_codegen(input: &str, output: &str) {
     let prog = parser().parse(input).unwrap();
     let result: String = codegen_prog(&prog);

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -1,7 +1,7 @@
 use chumsky::prelude::*;
 use test_case::test_case;
 
-use nouveau_lib::codegen::codegen_expr;
+use nouveau_lib::codegen::codegen_prog;
 use nouveau_lib::parser::parser;
 
 #[test_case("\"hello\"", "\"hello\""; "string literal")]
@@ -20,8 +20,8 @@ use nouveau_lib::parser::parser;
 #[test_case("a - b - c", "a - b - c"; "subtraction without parens")]
 #[test_case("a - (b - c)", "a - (b - c)"; "subtraction with parens")]
 fn parse_then_codegen(input: &str, output: &str) {
-    let expr = parser().parse(input).unwrap();
-    let result: String = codegen_expr(&expr);
+    let prog = parser().parse(input).unwrap();
+    let result: String = codegen_prog(&prog);
 
     assert_eq!(result, output);
 }

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -21,7 +21,7 @@ use nouveau_lib::parser::parser;
 #[test_case("a - (b - c)", "a - (b - c)"; "subtraction with parens")]
 fn parse_then_codegen(input: &str, output: &str) {
     let expr = parser().parse(input).unwrap();
-    let result = codegen_expr(&expr);
+    let result: String = codegen_expr(&expr);
 
     assert_eq!(result, output);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -27,13 +27,13 @@ fn infer_lam() {
 }
 
 #[test]
-fn infer_let() {
+fn infer_let_inside_function() {
     let env: Env = HashMap::new();
-    let prog = parser().parse("let x = 5 in x").unwrap();
+    let prog = parser().parse("() => let x = 5 in x").unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
 
-    assert_eq!(format!("{}", result), "5");
+    assert_eq!(format!("{}", result), "() => 5");
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,15 +2,16 @@ use chumsky::prelude::*;
 use std::collections::HashMap;
 
 use nouveau_lib::context::Env;
-use nouveau_lib::infer::infer_expr;
+use nouveau_lib::infer::infer_stmt;
 use nouveau_lib::parser::parser;
 use nouveau_lib::types::*;
 
 #[test]
 fn infer_number_literal() {
     let env: Env = HashMap::new();
-    let expr = parser().parse("5").unwrap();
-    let result = infer_expr(env, &expr);
+    let prog = parser().parse("5").unwrap();
+    let stmt = prog.body.get(0).unwrap();
+    let result = infer_stmt(env, &stmt);
 
     assert_eq!(format!("{}", result), "5");
 }
@@ -18,8 +19,9 @@ fn infer_number_literal() {
 #[test]
 fn infer_lam() {
     let env: Env = HashMap::new();
-    let expr = parser().parse("(x) => x").unwrap();
-    let result = infer_expr(env, &expr);
+    let prog = parser().parse("(x) => x").unwrap();
+    let stmt = prog.body.get(0).unwrap();
+    let result = infer_stmt(env, &stmt);
 
     assert_eq!(format!("{}", result), "<a1>(a1) => a1");
 }
@@ -27,8 +29,9 @@ fn infer_lam() {
 #[test]
 fn infer_let() {
     let env: Env = HashMap::new();
-    let expr = parser().parse("let x = 5 in x").unwrap();
-    let result = infer_expr(env, &expr);
+    let prog = parser().parse("let x = 5 in x").unwrap();
+    let stmt = prog.body.get(0).unwrap();
+    let result = infer_stmt(env, &stmt);
 
     assert_eq!(format!("{}", result), "5");
 }
@@ -36,8 +39,9 @@ fn infer_let() {
 #[test]
 fn infer_op() {
     let env: Env = HashMap::new();
-    let expr = parser().parse("5 + 10").unwrap();
-    let result = infer_expr(env, &expr);
+    let prog = parser().parse("5 + 10").unwrap();
+    let stmt = prog.body.get(0).unwrap();
+    let result = infer_stmt(env, &stmt);
 
     assert_eq!(format!("{}", result), "number");
 }


### PR DESCRIPTION
This is so that we can parse multi-line programs and have top-level "let" declarations that don't have a body like the normal `let`.