### PR TITLE
Add a lexing step before parsing tokens instead of chars

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,0 +1,267 @@
+use chumsky::prelude::*;
+use std::fmt;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum Token {
+    Ident(String),
+
+    // keywords
+    Let,
+    In,
+
+    // literals
+    Num(String), // We use string instead of f64 b/c f64 isn't hashable
+    Str(String),
+    // TODO: boolean
+
+    // operators
+    Minus,
+    Plus,
+    Times,
+    Div,
+    Eq,
+
+    // punct
+    OpenParen,
+    CloseParen,
+    Comma,
+    Semi,
+    FatArrow,
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Token::Num(num) => write!(f, "{}", num),
+            Token::Str(num) => write!(f, "\"{}\"", num),
+            Token::Ident(ident) => write!(f, "{}", ident),
+            Token::Minus => write!(f, "-"),
+            Token::Plus => write!(f, "+"),
+            Token::Times => write!(f, "*"),
+            Token::Div => write!(f, "/"),
+            Token::Let => write!(f, "let"),
+            Token::OpenParen => write!(f, "("),
+            Token::CloseParen => write!(f, ")"),
+            Token::Eq => write!(f, "="),
+            Token::Comma => write!(f, ","),
+            Token::Semi => write!(f, ";"),
+            Token::FatArrow => write!(f, "=>"),
+            Token::In => write!(f, "in"),
+        }
+    }
+}
+
+pub type Span = std::ops::Range<usize>;
+
+pub fn lexer() -> impl Parser<char, Vec<(Token, Span)>, Error = Simple<char>> {
+    // TODO: support parsing numbers that start with '.'
+    // let real = text::int(10)
+    //     .chain(just('.'))
+    //     .chain::<char, _, _>(text::digits(10))
+    //     .collect::<String>()
+    //     .map(|s: String| Token::Num(s.parse().unwrap()));
+
+    let int = text::int::<char, Simple<char>>(10).map(|s: String| Token::Num(s.parse().unwrap()));
+
+    let r#str = just("\"")
+        .ignore_then(filter(|c| *c != '"').repeated())
+        .then_ignore(just('"'))
+        .collect::<String>()
+        .map(|s| Token::Str(s));
+
+    let real = text::int(10)
+        .chain(just('.'))
+        .chain::<char, _, _>(text::digits(10))
+        .collect::<String>()
+        .map(|s: String| Token::Num(s.parse().unwrap()));
+
+    let op = choice((
+        just("+").to(Token::Plus),
+        just("-").to(Token::Minus),
+        just("*").to(Token::Times),
+        just("/").to(Token::Div),
+    ));
+
+    let punct = choice((
+        just(",").to(Token::Comma),
+        just("=>").to(Token::FatArrow), // must appear before '='
+        just("=").to(Token::Eq),
+        just("(").to(Token::OpenParen),
+        just(")").to(Token::CloseParen),
+        just(";").to(Token::Semi),
+    ));
+
+    let ident = text::ident::<char, Simple<char>>();
+
+    let word = ident.map(|s: String| match s.as_str() {
+        "let" => Token::Let,
+        "in" => Token::In,
+        _ => Token::Ident(s.clone()),
+    });
+
+    let token = choice((word, real, int, r#str, op, punct));
+
+    token
+        .map_with_span(move |token, span| (token, span))
+        .padded()
+        .repeated()
+        .then_ignore(end())
+}
+
+// TODO: prevent the parsing of keywords as identifiers
+
+// TODO: implement a parser that generates tokens from chars
+// pub fn parser() -> impl Parser<char, Token
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use super::super::lexer::lexer;
+
+    #[test]
+    fn fn_with_multiple_params() {
+        let tokens = lexer().parse("(a, b) => c").unwrap();
+        insta::assert_debug_snapshot!(tokens, @r###"
+        [
+            (
+                OpenParen,
+                0..1,
+            ),
+            (
+                Ident(
+                    "a",
+                ),
+                1..2,
+            ),
+            (
+                Comma,
+                2..3,
+            ),
+            (
+                Ident(
+                    "b",
+                ),
+                4..5,
+            ),
+            (
+                CloseParen,
+                5..6,
+            ),
+            (
+                FatArrow,
+                7..9,
+            ),
+            (
+                Ident(
+                    "c",
+                ),
+                10..11,
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn lex_string_literal() {
+        let tokens = lexer().parse("(a) => \"hello\"").unwrap();
+        insta::assert_debug_snapshot!(tokens, @r###"
+        [
+            (
+                OpenParen,
+                0..1,
+            ),
+            (
+                Ident(
+                    "a",
+                ),
+                1..2,
+            ),
+            (
+                CloseParen,
+                2..3,
+            ),
+            (
+                FatArrow,
+                4..6,
+            ),
+            (
+                Str(
+                    "hello",
+                ),
+                7..14,
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn lex_math_expr() {
+        let tokens = lexer().parse("1 + 2 - 3").unwrap();
+        insta::assert_debug_snapshot!(tokens, @r###"
+        [
+            (
+                Num(
+                    "1",
+                ),
+                0..1,
+            ),
+            (
+                Plus,
+                2..3,
+            ),
+            (
+                Num(
+                    "2",
+                ),
+                4..5,
+            ),
+            (
+                Minus,
+                6..7,
+            ),
+            (
+                Num(
+                    "3",
+                ),
+                8..9,
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn lex_math_with_identifiers() {
+        let tokens = lexer().parse("x * y / z").unwrap();
+        insta::assert_debug_snapshot!(tokens, @r###"
+        [
+            (
+                Ident(
+                    "x",
+                ),
+                0..1,
+            ),
+            (
+                Times,
+                2..3,
+            ),
+            (
+                Ident(
+                    "y",
+                ),
+                4..5,
+            ),
+            (
+                Div,
+                6..7,
+            ),
+            (
+                Ident(
+                    "z",
+                ),
+                8..9,
+            ),
+        ]
+        "###);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod codegen;
 pub mod constraint_solver;
 pub mod context;
 pub mod infer;
+pub mod lexer;
 pub mod literal;
 pub mod parser;
 pub mod substitutable;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use chumsky::prelude::*;
 use std::collections::HashMap;
 
 use nouveau_lib::parser::*;
+use nouveau_lib::lexer::*;
 use nouveau_lib::context::Env;
 use nouveau_lib::infer::*;
 
@@ -9,12 +10,18 @@ fn main() {
     println!("Hello, world!");
 
     let env: Env = HashMap::new();
-    let prog = parser().parse("5 + 10").unwrap();
+    let result = lexer().parse("5 + 10").unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
 
     assert_eq!(format!("{}", result), "number");
 
-    let ast = parser().parse("let x = 5 in x").unwrap();
+    let result = lexer().parse("let x = 5 in x").unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let ast = token_parser(&spans).parse(tokens).unwrap();
     println!("ast = {:?}", ast);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,8 +6,6 @@ use super::syntax::{BinOp, BindingIdent, Expr, Pattern, Program, Statement};
 
 pub type Span = std::ops::Range<usize>;
 
-// TODO: add lexing layer so that it's easier to separate keywords and identifiers
-
 pub fn token_parser(
     source_spans: &[Span],
 ) -> impl Parser<Token, Program, Error = Simple<Token>> + '_ {
@@ -483,102 +481,14 @@ mod tests {
         "###);
     }
 
-    // TODO: this test should panic because we don't want to support let-in at the top level
-    // Right now the parser treats `in` as identifier instead of a keyword.
-    // #[test]
-    // fn simple_let() {
-    //     insta::assert_debug_snapshot!(parser().parse("let x = 5 in x").unwrap(), @r###"
-    //     (
-    //         Let {
-    //             pattern: (
-    //                 Ident {
-    //                     name: "x",
-    //                 },
-    //                 4..5,
-    //             ),
-    //             value: (
-    //                 Lit {
-    //                     literal: Num(
-    //                         "5",
-    //                     ),
-    //                 },
-    //                 8..9,
-    //             ),
-    //             body: (
-    //                 Ident {
-    //                     name: "x",
-    //                 },
-    //                 13..14,
-    //             ),
-    //         },
-    //         0..14,
-    //     )
-    //     "###);
-    // }
-
-    // TODO: this test should panic because we don't want to support let-in at the top level
-    // Right now the parser treats `in` as identifier instead of a keyword.
-    // #[test]
-    // fn nested_let() {
-    //     insta::assert_debug_snapshot!(parser().parse("let x = 5 in let y = 10 in x + y").unwrap(), @r###"
-    //     (
-    //         Let {
-    //             pattern: (
-    //                 Ident {
-    //                     name: "x",
-    //                 },
-    //                 4..5,
-    //             ),
-    //             value: (
-    //                 Lit {
-    //                     literal: Num(
-    //                         "5",
-    //                     ),
-    //                 },
-    //                 8..9,
-    //             ),
-    //             body: (
-    //                 Let {
-    //                     pattern: (
-    //                         Ident {
-    //                             name: "y",
-    //                         },
-    //                         17..18,
-    //                     ),
-    //                     value: (
-    //                         Lit {
-    //                             literal: Num(
-    //                                 "10",
-    //                             ),
-    //                         },
-    //                         21..23,
-    //                     ),
-    //                     body: (
-    //                         Op {
-    //                             op: Add,
-    //                             left: (
-    //                                 Ident {
-    //                                     name: "x",
-    //                                 },
-    //                                 27..28,
-    //                             ),
-    //                             right: (
-    //                                 Ident {
-    //                                     name: "y",
-    //                                 },
-    //                                 31..32,
-    //                             ),
-    //                         },
-    //                         27..32,
-    //                     ),
-    //                 },
-    //                 13..32,
-    //             ),
-    //         },
-    //         0..32,
-    //     )
-    //     "###);
-    // }
+    #[test]
+    #[should_panic]
+    fn top_level_let_in_panics() {
+        let result = lexer().parse("let x = 5 in x").unwrap();
+        let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+        let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+        token_parser(&spans).parse(tokens).unwrap();
+    }
 
     #[test]
     fn add_sub_operations() {

--- a/tests/codegen_test.rs
+++ b/tests/codegen_test.rs
@@ -2,7 +2,8 @@ use chumsky::prelude::*;
 use test_case::test_case;
 
 use nouveau_lib::codegen::codegen_prog;
-use nouveau_lib::parser::parser;
+use nouveau_lib::parser::token_parser;
+use nouveau_lib::lexer::lexer;
 
 #[test_case("\"hello\"", "\"hello\""; "string literal")]
 #[test_case("123", "123"; "number literal (whole)")]
@@ -25,7 +26,10 @@ use nouveau_lib::parser::parser;
 #[test_case("let foo = let x = 5 in let y = 10 in x + y", "var foo = {\nvar x = 5;\nvar y = 10;\nreturn x + y;\n}"; "nested let-in expressions inside declaration")]
 // TODO: add a test case with multiple declarations
 fn parse_then_codegen(input: &str, output: &str) {
-    let prog = parser().parse(input).unwrap();
+    let result = lexer().parse(input).unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
     let result: String = codegen_prog(&prog);
 
     assert_eq!(result, output);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,13 +3,17 @@ use std::collections::HashMap;
 
 use nouveau_lib::context::Env;
 use nouveau_lib::infer::infer_stmt;
-use nouveau_lib::parser::parser;
+use nouveau_lib::parser::token_parser;
+use nouveau_lib::lexer::lexer;
 use nouveau_lib::types::*;
 
 #[test]
 fn infer_number_literal() {
     let env: Env = HashMap::new();
-    let prog = parser().parse("5").unwrap();
+    let result = lexer().parse("5").unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
 
@@ -19,7 +23,10 @@ fn infer_number_literal() {
 #[test]
 fn infer_lam() {
     let env: Env = HashMap::new();
-    let prog = parser().parse("(x) => x").unwrap();
+    let result = lexer().parse("(x) => x").unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
 
@@ -29,7 +36,10 @@ fn infer_lam() {
 #[test]
 fn infer_let_inside_function() {
     let env: Env = HashMap::new();
-    let prog = parser().parse("() => let x = 5 in x").unwrap();
+    let result = lexer().parse("() => let x = 5 in x").unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
 
@@ -39,7 +49,10 @@ fn infer_let_inside_function() {
 #[test]
 fn infer_op() {
     let env: Env = HashMap::new();
-    let prog = parser().parse("5 + 10").unwrap();
+    let result = lexer().parse("5 + 10").unwrap();
+    let spans: Vec<_> = result.iter().map(|(_, s)| s.to_owned()).collect();
+    let tokens: Vec<_> = result.iter().map(|(t, _)| t.to_owned()).collect();
+    let prog = token_parser(&spans).parse(tokens).unwrap();
     let stmt = prog.body.get(0).unwrap();
     let result = infer_stmt(env, &stmt);
 


### PR DESCRIPTION
This made differentiating between keywords and identifiers easier.